### PR TITLE
fix 406 not acceptable due to missing headers, remove unit test asser…

### DIFF
--- a/Api/HttpUtility.cs
+++ b/Api/HttpUtility.cs
@@ -131,6 +131,9 @@ namespace KoenZomers.Ring.Api
                 }
             }
 
+            // Always add the User-Agent header
+            request.Headers.UserAgent.TryParseAdd("android:com.ringapp");
+
             // Set the content for the HTTP request
             request.Content = new FormUrlEncodedContent(formFields);
 

--- a/Api/Session.cs
+++ b/Api/Session.cs
@@ -249,7 +249,7 @@ namespace KoenZomers.Ring.Api
 
             var headerFields = new NameValueCollection()
             { 
-                { "hardware_id", "unespecified" }
+                { "hardware_id", "unspecified" }
             };
             // Make the Form POST request to request an OAuth Token
             try

--- a/Api/Session.cs
+++ b/Api/Session.cs
@@ -165,6 +165,7 @@ namespace KoenZomers.Ring.Api
             {
                 headerFields.Add("2fa-support", "true");
                 headerFields.Add("2fa-code", twoFactorAuthCode);
+                headerFields.Add("hardware_id", hardwareId);
             }
 
             // Make the Form POST request to request an OAuth Token

--- a/Api/Session.cs
+++ b/Api/Session.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Threading;
 using System.Text.Json;
 using KoenZomers.Ring.Api.Entities;
+using System.Collections.Specialized;
 
 namespace KoenZomers.Ring.Api
 {
@@ -160,12 +161,14 @@ namespace KoenZomers.Ring.Api
             };
 
             // If a two factor auth code has been provided, add the code through the HTTP POST header
-            var headerFields = new System.Collections.Specialized.NameValueCollection();
+            var headerFields = new NameValueCollection(capacity: 3) 
+            {
+                { "hardware_id", hardwareId }
+            };
             if (twoFactorAuthCode != null)
             {
                 headerFields.Add("2fa-support", "true");
                 headerFields.Add("2fa-code", twoFactorAuthCode);
-                headerFields.Add("hardware_id", hardwareId);
             }
 
             // Make the Form POST request to request an OAuth Token
@@ -244,12 +247,16 @@ namespace KoenZomers.Ring.Api
                 { "refresh_token", refreshToken }
             };
 
+            var headerFields = new NameValueCollection()
+            { 
+                { "hardware_id", "unespecified" }
+            };
             // Make the Form POST request to request an OAuth Token
             try
             {
                 var oAuthResponse = await _httpUtility.FormPost(RingApiOAuthUrl,
                                                                 oAuthformFields,
-                                                                null);
+                                                                headerFields);
 
 
                 // Deserialize the JSON result into a typed object

--- a/UnitTest/UnitTest.cs
+++ b/UnitTest/UnitTest.cs
@@ -103,7 +103,7 @@ namespace KoenZomers.Ring.UnitTest
                 {
                     Assert.Fail("The two factor authentication token provided in the config file as 'TwoFactorAuthenticationToken' is invalid or has expired.");
                 }
-                Assert.IsFalse(authResult == null || string.IsNullOrEmpty(authResult.Profile?.AuthenticationToken), "Failed to authenticate");
+                Assert.IsFalse(authResult == null, "Failed to authenticate");
 
                 // Store the refresh token for subsequent runs
                 RefreshToken = session.OAuthToken.RefreshToken;


### PR DESCRIPTION
Recently auth started failing due to missing headers in Auth requests, based on https://github.com/dgreif/ring/blob/main/packages/ring-client-api/rest-client.ts added the missing headers.

Updated unit tests, session api doesn't return Auth token anymore. This solves issue #31 